### PR TITLE
growth_hk_logger.rb - HK Logger added

### DIFF
--- a/controller/bin/growth_hk_logger.rb
+++ b/controller/bin/growth_hk_logger.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+
+require "growth_controller/logger"
+require "growth_controller/config"
+require "growth_controller/console_modules"
+
+# Loggs HK data.
+
+class HKLogger
+
+  SAMPLING_PERIOD_SEC = 120
+  FILE_SWITCHING_PERIOD_SEC = 86400 * 7
+  
+  def initialize()
+    @logger = GROWTH.logger(ARGV, "growth_hk_logger")
+    @growth_config = GROWTH::Config.new(logger: @logger)
+
+    @hv = GROWTH::ConsoleModuleHV.new("hv", logger: @logger)  
+    @hk = GROWTH::ConsoleModuleHK.new("hk", logger: @logger)
+    @daq = GROWTH::ConsoleModuleDAQ.new("daq", logger: @logger)
+    
+    @output_file_name = ""
+    @output_file = nil
+    @file_creation_time_unix_time = 0
+  end
+  
+  def run()
+    while(true)
+      switch_output_file()
+      # Time stamp
+      unix_time = Time.now().to_i()
+      # Read HK/status from subsystems
+      hk_data = @hk.read()
+      daq_status = @daq.status()
+      hv_status = @hv.stats()
+      # Write to file if output file is opened
+      if(@output_file!=nil)then
+        line = { timestamp: unix_time, hk: hk_data, daq: daq_status, hv: hv_status}
+        @output_file.puts line
+      else
+        @logger.warn("Output file is nil (should not reach here)")
+      end
+      # Wait until next sampling
+      sleep(SAMPLING_PERIOD_SEC)
+    end
+  end
+
+  def switch_output_file()
+    if(@output_file==nil or should_switch_output_file())then
+      if(@output_file!=nil)then
+        @logger.info("Closing #{@output_file_name}")
+        @output_file.close()
+        try_compress()
+      end
+      @logger.info("New log file #{@output_file_name} was created")
+      @output_file_name = get_new_output_file_name()
+      begin
+        @output_file = open(@output_file_name)
+        @logger.info("New log file #{@output_file_name} was created")
+      rescue => e
+        @logger.fatal("Failed to create #{@output_file_name} (#{e})")
+        exit 1
+      end
+    end
+  end
+
+  private
+  def should_switch_output_file()
+    now_unix_time = Time.now().to_i()
+    if (now_unix_time - @file_creation_time_unix_time) >= FILE_SWITCHING_PERIOD_SEC then
+      return true
+    else
+      return false
+    end
+  end
+
+  def try_compress()
+    if(File.exist?(@output_file_name))then
+      original_size_kb = File.size(@output_file_name)/1024.0
+      @logger.info("Compressing #{@output_file_name}")
+      `gzip #{@output_file_name}`
+      if(File.exist?(@output_file_name+".gz"))then
+        compressed_size_kb = File.size(@output_file_name+".gz")/1024.0
+        ratio_percent = compressed_size_kb / original_size_kb * 100
+        @logger.info(
+          "Successfully compressed from %.1fkB to %.1fkB (%.1f%%)" % [
+           original_size_kb, compressed_size_kb, ratio_percent]
+        )
+      else
+        @logger.warn("Failed to compress")
+      end
+    end
+  end
+
+  def get_new_output_file_name()
+    now = Time.now()
+    @file_creation_time_unix_time = now.to_i()
+    return now.strftime("hk_%Y%m$d_%H%M%S.text")
+  end
+
+end
+
+hk_logger = HKLogger.new()
+hk_logger.run()

--- a/controller/god/growth.god.conf
+++ b/controller/god/growth.god.conf
@@ -118,7 +118,7 @@ EOS
   w.dir = GROWTH_DAQ_RUN_DIR
   w.start_if do |start|
     start.condition(:process_running) do |c|
-      c.interval = 30.seconds
+      c.interval = 60.seconds
       c.running = false
     end
   end
@@ -129,6 +129,9 @@ God.watch do |w|
   w.name = 'growth_hk_logger'
   w.start = "#{GROWTH_CONTROLLER_BIN_DIR}/growth_hk_logger.rb --log-level=info --log-device=file --log-dir=#{LOG_DIR}"
   w.env = ADDITIONAL_ENV
+  # Execute DAQ program as pi user
+  w.uid = "pi"
+  w.gid = "pi"
   w.dir = GROWTH_DAQ_RUN_DIR
   w.start_if do |start|
     start.condition(:process_running) do |c|

--- a/controller/god/growth.god.conf
+++ b/controller/god/growth.god.conf
@@ -123,3 +123,16 @@ EOS
     end
   end
 end
+
+# growth_hk_logger
+God.watch do |w|
+  w.name = 'growth_hk_logger'
+  w.start = "#{GROWTH_CONTROLLER_BIN_DIR}/growth_hk_logger.rb --log-level=info --log-device=file --log-dir=#{LOG_DIR}"
+  w.env = ADDITIONAL_ENV
+  w.start_if do |start|
+    start.condition(:process_running) do |c|
+      c.interval = 60.seconds
+      c.running = false
+    end
+  end
+end

--- a/controller/god/growth.god.conf
+++ b/controller/god/growth.god.conf
@@ -129,6 +129,7 @@ God.watch do |w|
   w.name = 'growth_hk_logger'
   w.start = "#{GROWTH_CONTROLLER_BIN_DIR}/growth_hk_logger.rb --log-level=info --log-device=file --log-dir=#{LOG_DIR}"
   w.env = ADDITIONAL_ENV
+  w.dir = GROWTH_DAQ_RUN_DIR
   w.start_if do |start|
     start.condition(:process_running) do |c|
       c.interval = 60.seconds

--- a/controller/lib/growth_controller/console_modules.rb
+++ b/controller/lib/growth_controller/console_modules.rb
@@ -35,7 +35,7 @@ class ConsoleModule < LoggingInterface
 
 	def send_command(command, option_hash={})
 		json_command = {command: name+"."+command, option: option_hash}.to_json
-		log_info("Sending command: #{json_command}")
+		log_debug("Sending command: #{json_command}")
 		begin
 			if(@requester==nil)then
 				connect()

--- a/controller/lib/rpi/bme280.rb
+++ b/controller/lib/rpi/bme280.rb
@@ -30,7 +30,7 @@ module RPi
 	class BME280
 		include Validations
 		
-		ADDRESS = 0x76
+		ADDRESS = 0x77
 		
 		R_DIG_T1 = 0x88
 		R_DIG_P1 = 0x8E


### PR DESCRIPTION
@YuukiWada @tenoto 

HK記録用のスクリプトを用意してみました。
`controller/bin/growth_hk_logger.rb`に入っています。

このブランチをRaspberry Piにfetch/checkoutして以下のようにgodの設定ファイルを再インストール、再起動すると、`growth-fy2016x/`以下に、HKファイルができると思います。サンプリング間隔とファイル切り替えの時間はスクリプト内で定義していて、現状、サンプリング間隔は2分、ファイル切り替えは1日ごとになっています。

```
cd git/GROWTH-DAQ/controller
git fetch origin
git checkout yuasa-hk-logger
sudo make
sudo reboot
```

出力は以下のようなJSON形式です。オフライン解析でDBに入れるか、ROOTに変換してプロットできるようにしましょう。

```
{"timestamp":1475074935,"hk":{"status":"ok","unixtime":1475074935,"time":"2016-09-28T15-02-15","hk":{"slow_adc":{"0":{"raw":894,"voltage":0.7204395604395604,"converted_value":47.430329670329655,"converted_string":"FPGA Temperature 47.43 degC","units":"degC"},"1":{"raw":902,"voltage":0.7268864468864469,"converted_value":48.4618315018315,"converted_string":"DCDC Temperature 48.46 degC","units":"degC"},"2":{"raw":555,"voltage":0.4472527472527472,"converted_value":447.2527472527472,"converted_string":" 12V Current 447.3 mA","units":"mA"},"3":{"raw":479,"voltage":0.386007326007326,"converted_value":193.003663003663,"converted_string":"  5V Current 193.0 mA","units":"mA"},"4":{"raw":556,"voltage":0.448058608058608,"converted_value":448.058608058608,"converted_string":"3.3V Current 448.1 mA","units":"mA"},"5":{"raw":4013,"voltage":3.2339194139194136,"converted_value":4013,"converted_string":"Slow ADC 5","units":"ch"},"6":{"raw":4012,"voltage":3.2331135531135526,"converted_value":4012,"converted_string":"Slow ADC 6","units":"ch"},"7":{"raw":4013,"voltage":3.2339194139194136,"converted_value":4013,"converted_string":"Slow ADC 7","units":"ch"}},"bme280":{},"slide_switch":"on"},"subsystem":"hk"},"daq":{"daqStatus":"Paused","elapsedTime":962,"elapsedTimeOfCurrentOutputFile":0,"nEvents":4,"nEventsOfCurrentOutputFile":4,"outputFileName":"None","status":"ok","unixTime":1475074935,"subsystem":"daq"},"hv":{"status":"ok","0":{"status":"off","value_in_mV":0},"1":{"status":"off","value_in_mV":0},"subsystem":"hv"}}
```

ログは以下のようにすると確認できます。ファイルを切り替えるときに過去のファイルをgzipで圧縮するので、ディスク容量とデータ通信量の節約になります。

```
$ tail -100 /var/log/growth/growth_hk_logger.log

I, [2016-09-28T14:49:19.167366 #3074]  INFO -- growth_hk_logger: Closing hk_20160928_144736.text
I, [2016-09-28T14:49:19.167777 #3074]  INFO -- growth_hk_logger: Compressing hk_20160928_144736.text
I, [2016-09-28T14:49:19.179042 #3074]  INFO -- growth_hk_logger: Successfully compressed from 25.9kB to 2.0kB (7.8%)
I, [2016-09-28T14:49:19.179443 #3074]  INFO -- growth_hk_logger: Current directory = /home/pi/work/growth/data/growth-fy2016a
I, [2016-09-28T14:49:19.179727 #3074]  INFO -- growth_hk_logger: New log file hk_20160928_144919.text was created
```

動作試験してみてください。OKならmasterにmergeします。
