### PR TITLE
growth_remote_command_executor

### DIFF
--- a/controller/bin/growth_remote_command_executor.rb
+++ b/controller/bin/growth_remote_command_executor.rb
@@ -1,0 +1,178 @@
+#!/usr/bin/env ruby
+
+require "growth_controller/logger"
+require "growth_controller/config"
+require "growth_controller/keys"
+require "json"
+require "uri"
+require "net/http"
+require "date"
+
+# Transmit telemtry data to M2X and/or other cloud-base storage.
+
+class RemoteCommandExecutor
+
+  COMMAND_FETCH_PERIOD_SEC = 600
+  COMMAND_TIMESTAMP_LOG_FILE_PATH = "/var/log/growth/command.timestamp.log"
+
+  def initialize()
+    @logger = GROWTH.logger(ARGV, "growth_remote_command_executor")
+    @growth_config = GROWTH::Config.new(logger: @logger)
+
+    # Timestamp of the last executed command
+    @last_command_timestamp = get_last_command_timestamp()
+
+    # Command download URI
+    @uri = URI.parse("https://thdr.info/command/#{@growth_config.detector_id}/command.json")
+    @logger.info "Command JSON file fetched from #{@uri}"
+  end
+  
+  def run()
+    while(true)
+      commands = nil
+      # Fetch command JSON file
+      begin
+        json = Net::HTTP.get(@uri)
+        @logger.info "Command file fetched successfully"
+        begin
+          commands = JSON.parse(json)
+        rescue => e
+          @logger.error "Failed to parse command file (#{e})"
+        end
+      rescue => e
+        @logger.error "Failed to fetch command file (#{e})"
+      end
+
+      # Parse/execute command
+      parse_commands(commands) if commands!=nil
+
+      # Wait until next fetch
+      sleep(COMMAND_FETCH_PERIOD_SEC)
+    end
+  end
+
+  private
+  def parse_commands(commands)
+    commands.each(){|command_entry|
+      
+      # Check the command id and the creation date/time to avoid double execution
+      created_at = command_entry["created_at"]
+      begin
+        command_timestamp = DateTime.parse(created_at)
+        if(command_timestamp <= @last_command_timestamp)then
+          @logger.info "Skipping old command timestamped at #{command_timestamp}"
+          next
+        end
+      rescue => e
+        @logger.error "Could not parse #{command_entry.to_s} (#{e})"
+        next
+      end
+
+      # Handle command if defined
+      command = command_entry["command"]
+      option = command_entry["option"]
+      if(command!=nil)then
+        command.strip!()
+        if(command=="upload")then
+          command_upload(option)
+        end
+        # Update the last command timestamp regardless of the execution
+        # result (success/fail)
+        update_last_command_timestamp(command_timestamp)
+      else
+        @logger.error "Undefined command #{command}"
+      end
+    }
+  end
+
+  private
+  def get_last_command_timestamp()
+    default_timestamp = DateTime.now
+    if(File.exist?(COMMAND_TIMESTAMP_LOG_FILE_PATH))then
+      begin
+        timestamp = DateTime.parse(File.read(COMMAND_TIMESTAMP_LOG_FILE_PATH).strip)
+        @logger.info "Cached last command timestamp = #{timestamp}"
+        return timestamp
+      rescue => e
+        @logger.error "Invalid cache file at #{COMMAND_TIMESTAMP_LOG_FILE_PATH}. Deleting..."
+        begin
+          FileUtils.rm(COMMAND_TIMESTAMP_LOG_FILE_PATH)
+          @logger.warn "Cache file #{COMMAND_TIMESTAMP_LOG_FILE_PATH} deleted"
+        rescue => e
+          @logger.error "Failed to delete the invalid cache file"
+        end
+        @logger.info "Using default last command timestamp #{default_timestamp}"
+        return default_timestamp
+      end
+    else
+      # Otherwise, return a default timestamp
+      @logger.info "Using default last command timestamp #{default_timestamp}"
+      return default_timestamp
+    end
+  end
+
+  private
+  def update_last_command_timestamp(command_timestamp)
+    @logger.info "Updating the last command timestamp cache"
+    @last_command_timestamp = command_timestamp
+    begin
+      file = open(COMMAND_TIMESTAMP_LOG_FILE_PATH, "w")
+      file.puts command_timestamp
+      file.close
+      @logger.info "Updated to #{command_timestamp}"
+    rescue => e
+      @logger.fatal "Failed to write to #{COMMAND_TIMESTAMP_LOG_FILE_PATH} (#{e})"
+      exit 1
+    end
+  end
+
+  private
+  def command_upload(option)
+    @logger.info "Executing 'upload' command (option = #{option})"
+    if(option["from"]==nil or option["to"]==nil)then
+      @logger.error "'from' and 'to' are expected in the 'option' map"
+      return
+    end
+
+    begin
+      from_datetime = DateTime.parse(option["from"])
+      to_datetime = DateTime.parse(option["to"])
+      from_yyyymm = from_datetime.year * 100 + from_datetime.month
+      to_yyyymm = to_datetime.year * 100 + to_datetime.month
+      from_yyyymmddhhmmss = from_yyyymm * 1e8 + from_datetime.day * 1e6 + from_datetime.hour * 1e4 + from_datetime.minute * 1e2 + from_datetime.second
+      to_yyyymmddhhmmss = to_yyyymm * 1e8 + to_datetime.day * 1e6 + to_datetime.hour * 1e4 + to_datetime.minute * 1e2 + to_datetime.second
+
+      # Process YYYYMM directories
+      Dir.glob("#{@growth_config.daq_run_dir}/20[0-9]*/").sort().each(){|dir|
+        yyyymm = dir.split("/")[-1].to_i
+        if(from_yyyymm<=yyyymm and yyyymm<=to_yyyymm)then
+          @logger.info "Processing #{dir}"
+          # Enter if this is a directory within the specified range
+          Dir.glob("#{dir}/*20*.gz").sort().each(){|gz_file_path|
+            @logger.debug "Processing #{gz_file_path}"
+            timestamp = extract_yyyymmdd_hhmmss_as_integer(gz_file_path)
+            @logger.debug "Timestamp = #{timestamp}"
+            if(from_yyyymmddhhmmss<=timestamp and timestamp<=to_yyyymmddhhmmss)then
+              @logger.info "Upload #{File.basename(gz_file_path)}"
+            end
+          }
+        end
+      }
+    rescue => e
+      @logger.error e.to_s
+      return
+    end
+  end
+
+  private
+  def extract_yyyymmdd_hhmmss_as_integer(str)
+    if(str.match(/20[0-9]{6}_[0-9]{6}/))then
+      return Regexp.last_match(0).to_s.gsub("_","").to_i
+    else
+      return 0
+    end
+  end
+end
+
+remote_command_executor = RemoteCommandExecutor.new()
+remote_command_executor.run()

--- a/controller/god/growth.god.conf
+++ b/controller/god/growth.god.conf
@@ -15,20 +15,22 @@ begin
 	if(yaml["detectorID"]==nil)then
 		STDERR.puts "Error: detectorID is not defined in #{GROWTH_CONFIG_FILE}"
 	end
-	@detectorID = yaml["detectorID"]
+	@detector_id = yaml["detectorID"]
 rescue
 	STDERR.puts "Error: #{GROWTH_CONFIG_FILE} parse error"
+  exit(-1)
 end
 
+# Define constants
 LOG_DIR = "/var/log/growth"
 GIT_DIR = "/home/pi/git"
 GROWTH_DAQ_GIT_DIR = "#{GIT_DIR}/GROWTH-DAQ/"
 GROWTH_CONTROLLER_LIB_DIR = "#{GROWTH_DAQ_GIT_DIR}/controller/lib"
 GROWTH_CONTROLLER_BIN_DIR = "#{GROWTH_DAQ_GIT_DIR}/controller/bin"
-GROWTH_DAQ_RUN_DIR = "/home/pi/work/growth/data/#{@detectorID}"
+GROWTH_DAQ_RUN_DIR = "/home/pi/work/growth/data/#{@detector_id}"
 GROWTH_DAQ_LOG = "#{LOG_DIR}/growth_daq.log"
 GROWTH_DAQ_DEVICE = "/dev/ttyUSB1"
-GROWTH_DAQ_CONFIG = "#{GROWTH_DAQ_GIT_DIR}/daq/configurationFile/configuration_#{@detectorID}.yaml"
+GROWTH_DAQ_CONFIG = "#{GROWTH_DAQ_GIT_DIR}/daq/configurationFile/configuration_#{@detector_id}.yaml"
 GROWTH_DAQ_EXPOSURE = 0
 
 # Create folder if does not exist

--- a/controller/god/growth.god.conf
+++ b/controller/god/growth.god.conf
@@ -188,3 +188,21 @@ God.watch do |w|
     end
   end
 end
+
+#---------------------------------------------
+# growth_remote_command_executor
+#---------------------------------------------
+God.watch do |w|
+  w.name = 'growth_remote_command_executor'
+  w.start = "#{GROWTH_CONTROLLER_BIN_DIR}/growth_remote_command_executor.rb --log-level=info --log-device=file --log-dir=#{LOG_DIR}"
+  w.env = ADDITIONAL_ENV
+  # Execute file relocation script as pi user
+  w.uid = "pi"
+  w.gid = "pi"
+  w.start_if do |start|
+    start.condition(:process_running) do |c|
+      c.interval = 60.seconds
+      c.running = false
+    end
+  end
+end

--- a/controller/lib/growth_controller/config.rb
+++ b/controller/lib/growth_controller/config.rb
@@ -8,6 +8,8 @@ module GROWTH
     DEFAULT_DAQ_EXPOSURE_SEC = 1800
     DEFAULT_HK_SAMPLING_PERIOD = 120
 
+    GROWTH_DAQ_RUN_ROOT_DIR = "/home/pi/work/growth/data"
+
     def initialize(logger: nil)
       @growth_config_file = ""
       # Set config file path
@@ -30,6 +32,9 @@ module GROWTH
 
       # Load configuration file
       load_config_file()
+
+      # Set misc parameters
+      @daq_run_dir = "#{GROWTH_DAQ_RUN_ROOT_DIR}/#{@detector_id}"
     end
 
     attr_accessor :detector_id
@@ -40,7 +45,8 @@ module GROWTH
     attr_accessor :has_hv_limit
     attr_accessor :autorun_daq_exposure_sec
     attr_accessor :autorun_hk_sampling_period_sec
-
+    attr_accessor :daq_run_dir
+    
     def growth_config_file_path()
       return @growth_config_file
     end


### PR DESCRIPTION
@tenoto @YuukiWada 
- Retrieve a JSON command file from the server.
- Executes remote commands written in the JSON file.
- Implemented command:
  - 'upload' - uploads event files to the server

Log of example execution of 'upload' command:

```
I, [2016-10-22T20:27:45.679782 #13517]  INFO -- growth_remote_command_executor: [config] growth_config = /home/pi/growth_config.yaml
I, [2016-10-22T20:27:45.680093 #13517]  INFO -- growth_remote_command_executor: [config] Loading /home/pi/growth_config.yaml
I, [2016-10-22T20:27:45.685089 #13517]  INFO -- growth_remote_command_executor: [config] detectorID: growth-fy2016e
I, [2016-10-22T20:27:45.685468 #13517]  INFO -- growth_remote_command_executor: [config] HV Ch.0 HV_V = (x/3300)*1650
I, [2016-10-22T20:27:45.685646 #13517]  INFO -- growth_remote_command_executor: [config] HV Ch.1 HV_V = (x/3300)*1650
I, [2016-10-22T20:27:45.685790 #13517]  INFO -- growth_remote_command_executor: [config] HV Ch.0 DAC_mV = 0
I, [2016-10-22T20:27:45.685905 #13517]  INFO -- growth_remote_command_executor: [config] HV Ch.1 DAC_mV = 1800
I, [2016-10-22T20:27:45.686064 #13517]  INFO -- growth_remote_command_executor: [config] Temprature limit lower = -50 degC
I, [2016-10-22T20:27:45.686252 #13517]  INFO -- growth_remote_command_executor: [config] Temprature limit upper = 60 degC
I, [2016-10-22T20:27:45.686415 #13517]  INFO -- growth_remote_command_executor: [config] HV limit Ch.0 = 1000 V
I, [2016-10-22T20:27:45.686533 #13517]  INFO -- growth_remote_command_executor: [config] HV limit Ch.1 = 1000 V
I, [2016-10-22T20:27:45.686834 #13517]  INFO -- growth_remote_command_executor: Using default last command timestamp 2016-10-22T20:27:45+09:00
I, [2016-10-22T20:27:45.688871 #13517]  INFO -- growth_remote_command_executor: Command JSON file fetched from command/growth-fy2016e/command.json
I, [2016-10-22T20:27:45.834373 #13517]  INFO -- growth_remote_command_executor: Command file fetched successfully
I, [2016-10-22T20:27:45.841904 #13517]  INFO -- growth_remote_command_executor: Skipping old command timestamped at 2016-10-16T12:14:00+00:00
I, [2016-10-22T20:27:45.842458 #13517]  INFO -- growth_remote_command_executor: Executing 'upload' command (option = {"from"=>"20161018_0000", "to"=>"20161018_0300"})
I, [2016-10-22T20:27:45.845709 #13517]  INFO -- growth_remote_command_executor: Processing /home/pi/work/growth/data/growth-fy2016e/201610/
I, [2016-10-22T20:27:45.891909 #13517]  INFO -- growth_remote_command_executor: Upload /home/pi/work/growth/data/growth-fy2016e/201610//20161018_002825.fits.gz
I, [2016-10-22T20:27:45.892306 #13517]  INFO -- growth_remote_command_executor: Executing shell command 'rsync -auv  /home/pi/work/growth/data/growth-fy2016e/201610//20161018_002825.fits.gz thdr:growth-data/upload/growth-fy2016e_-_201610_-_20161018_002825.fits.gz'
I, [2016-10-22T20:27:46.319656 #13517]  INFO -- growth_remote_command_executor: Status = pid 13519 exit 0
```

Uploaded files:

```
$ ls growth-data/upload 
growth-fy2016e_-_201610_-_20161018_002825.fits.gz
growth-fy2016e_-_201610_-_20161018_005829.fits.gz
growth-fy2016e_-_201610_-_20161018_012833.fits.gz
growth-fy2016e_-_201610_-_20161018_015836.fits.gz
growth-fy2016e_-_201610_-_20161018_022840.fits.gz
growth-fy2016e_-_201610_-_20161018_025844.fits.gz
```
