### PR TITLE
PR: m2x gem added to setup script

### DIFF
--- a/setup/install_ruby_gem.sh
+++ b/setup/install_ruby_gem.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+set -e
+
 gem install pi_piper
 gem install git
 gem install rbczmq
 gem install pry
 gem install god
+gem install m2x


### PR DESCRIPTION
Hi @YuukiWada 

I've added `m2x` gem to `install_ruby_gem.sh`.
By running this, `m2x` will be available on Raspberry Pi and `growth_telemetry_transmitter.rb` should work without error.