### PR TITLE
PR: FPGA image (all 50MHz with GPS NMEA output on Bank B of FT2232) 

### DIFF
--- a/fpga/mcs/.gitattributes
+++ b/fpga/mcs/.gitattributes
@@ -1,0 +1,2 @@
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.mcs filter=lfs diff=lfs merge=lfs -text

--- a/fpga/mcs/growth_fy2016_fpga_20170706_2145_4ch_50Msps_with_gps.mcs.zip
+++ b/fpga/mcs/growth_fy2016_fpga_20170706_2145_4ch_50Msps_with_gps.mcs.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac8fb3d3af3a7ac22f9e95b55b328f0ee2d2bf4488f9a7cf08923f2401eedae7
+size 826191


### PR DESCRIPTION
- New FPGA image added to git lfs to reduce the actual repo size.
  - `growth_fy2016_fpga_20170706_2145_4ch_50Msps_with_gps.mcs.zip`
- Use `git lfs pull` to pull files stored on git lfs.
- Reviewer: @YuukiWada 