### PR TITLE
PR: Boot count of Raspberry Pi

### DIFF
--- a/controller/bin/growth_increment_boot_count.rb
+++ b/controller/bin/growth_increment_boot_count.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+BOOT_COUNT_FILE = "/home/pi/bootcount.text"
+
+if File.exist?(BOOT_COUNT_FILE) then
+  str = open(BOOT_COUNT_FILE).read()
+  count = str.to_i
+  output_file = open(BOOT_COUNT_FILE, "w")
+  output_file.puts count+1
+  output_file.close
+else
+  output_file = open(BOOT_COUNT_FILE, "w")
+  output_file.puts "1"
+  output_file.close
+end

--- a/controller/bin/growth_increment_boot_count.rb
+++ b/controller/bin/growth_increment_boot_count.rb
@@ -13,3 +13,6 @@ else
   output_file.puts "1"
   output_file.close
 end
+
+# Wait until Raspberry Pi is rebooted
+sleep

--- a/controller/god/growth.god.conf
+++ b/controller/god/growth.god.conf
@@ -225,3 +225,21 @@ God.watch do |w|
     end
   end
 end
+
+#---------------------------------------------
+# growth_increment_boot_count.rb
+#---------------------------------------------
+God.watch do |w|
+  w.name = 'growth_increment_boot_count'
+  w.start = "#{GROWTH_CONTROLLER_BIN_DIR}/growth_increment_boot_count.rb"
+  w.env = ADDITIONAL_ENV
+  # Execute boot count increment script as pi user
+  w.uid = "pi"
+  w.gid = "pi"
+  w.start_if do |start|
+    start.condition(:process_running) do |c|
+      c.interval = 86400.seconds
+      c.running = false
+    end
+  end
+end

--- a/controller/lib/growth_controller/hk.rb
+++ b/controller/lib/growth_controller/hk.rb
@@ -4,6 +4,8 @@ require "rpi"
 
 module GROWTH
 
+BOOT_COUNT_FILE = "/home/pi/bootcount.text"
+
 class ControllerModuleHK < ControllerModule
 
 	# I2C bus number to be used
@@ -89,11 +91,21 @@ class ControllerModuleHK < ControllerModule
 			slide_switch_status = "off"
 		end
 
+		# Boot count
+		boot_count = -1
+		if File.exist?(BOOT_COUNT_FILE) then
+			boot_count = File.read(BOOT_COUNT_FILE).to_i
+		end
+
 		# Return result
 		time = Time.now
 		return {
 			status: "ok", unixtime:time.to_i, time:time.strftime("%Y-%m-%dT%H-%M-%S"),
-			hk: {slow_adc:slowadc_result, bme280:bme280_result, slide_switch: slide_switch_status}
+			hk: {
+			    slow_adc:slowadc_result, bme280:bme280_result,
+			    slide_switch: slide_switch_status,
+			    boot_count: boot_count
+			}
 		}
 	end
 end


### PR DESCRIPTION
Changes:
- Added boot count file and increment script.
- God config also modified to start increment script on boot.
- Boot count is included in the HK JSON data.

Reviewer:
- @YuukiWada 

Test result:
1. `sudo make` in `controller` to install changes.
2. `growth_console.rb`

```
pi@raspberrypi[~]$ growth_console.rb
hk.
From: /home/pi/git/GROWTH-DAQ/controller/bin/growth_console.rb @ line 21 :

    16: daq  = GROWTH::ConsoleModuleDAQ.new("daq", logger: @logger)
    17: 
    18: #---------------------------------------------
    19: # Start console
    20: #---------------------------------------------
 => 21: binding.pry

[1] pry(main)> hk.read()
D, [2017-10-24T01:56:16.683699 #16406] DEBUG -- : [hk] Sending command: {"command":"hk.read","option":{}}
I, [2017-10-24T01:56:16.683991 #16406]  INFO -- : [hk] Connecting to Controller...
I, [2017-10-24T01:56:16.687485 #16406]  INFO -- : [hk] Connected to Controller
=> {"status"=>"ok",
 "unixtime"=>1508777776,
 "time"=>"2017-10-24T01-56-16",
 "hk"=>
  {"slow_adc"=>
    {"0"=>
      {"raw"=>804,
       "voltage"=>0.6479120879120879,
       "converted_value"=>35.82593406593406,
       "converted_string"=>"FPGA Temperature 35.83 degC",
       "units"=>"degC"},
     "1"=>
      {"raw"=>833,
       "voltage"=>0.6712820512820512,
       "converted_value"=>39.56512820512819,
       "converted_string"=>"DCDC Temperature 39.57 degC",
       "units"=>"degC"},
     "2"=>{"raw"=>675, "voltage"=>0.5439560439560439, "converted_value"=>543.9560439560439, "converted_string"=>" 12V Current 544.0 mA", "units"=>"mA"},
     "3"=>{"raw"=>477, "voltage"=>0.3843956043956044, "converted_value"=>192.1978021978022, "converted_string"=>"  5V Current 192.2 mA", "units"=>"mA"},
     "4"=>{"raw"=>333, "voltage"=>0.2683516483516483, "converted_value"=>268.3516483516483, "converted_string"=>"3.3V Current 268.4 mA", "units"=>"mA"},
     "5"=>{"raw"=>4024, "voltage"=>3.2427838827838826, "converted_value"=>4024, "converted_string"=>"Slow ADC 5", "units"=>"ch"},
     "6"=>{"raw"=>4020, "voltage"=>3.239560439560439, "converted_value"=>4020, "converted_string"=>"Slow ADC 6", "units"=>"ch"},
     "7"=>{"raw"=>4021, "voltage"=>3.2403663003663, "converted_value"=>4021, "converted_string"=>"Slow ADC 7", "units"=>"ch"}},
   "bme280"=>{"temperature"=>{"value"=>26.96, "units"=>"degC"}, "pressure"=>{"value"=>1012.99, "units"=>"mb"}, "humidity"=>{"value"=>42.8, "units"=>"%"}},
   "slide_switch"=>"off",
   "boot_count"=>4},  # <==== boot count is included here
 "subsystem"=>"hk"}
[2] pry(main)> 
```

After `sudo reboot`:
```
pi@raspberrypi[~]$ growth_console.rb

From: /home/pi/git/GROWTH-DAQ/controller/bin/growth_console.rb @ line 21 :

    16: daq  = GROWTH::ConsoleModuleDAQ.new("daq", logger: @logger)
    17: 
    18: #---------------------------------------------
    19: # Start console
    20: #---------------------------------------------
 => 21: binding.pry

[1] pry(main)> hk.read()
[1] pry(main)> hk.read()
D, [2017-10-24T01:57:14.383105 #1293] DEBUG -- : [hk] Sending command: {"command":"hk.read","option":{}}
I, [2017-10-24T01:57:14.383628 #1293]  INFO -- : [hk] Connecting to Controller...
I, [2017-10-24T01:57:14.387225 #1293]  INFO -- : [hk] Connected to Controller
=> {"status"=>"ok",
 "unixtime"=>1508777835,
 "time"=>"2017-10-24T01-57-15",
 "hk"=>
  {"slow_adc"=>
    {"0"=>
      {"raw"=>804,
       "voltage"=>0.6479120879120879,
       "converted_value"=>35.82593406593406,
       "converted_string"=>"FPGA Temperature 35.83 degC",
       "units"=>"degC"},
     "1"=>
      {"raw"=>833,
       "voltage"=>0.6712820512820512,
       "converted_value"=>39.56512820512819,
       "converted_string"=>"DCDC Temperature 39.57 degC",
       "units"=>"degC"},
     "2"=>{"raw"=>735, "voltage"=>0.5923076923076923, "converted_value"=>592.3076923076923, "converted_string"=>" 12V Current 592.3 mA", "units"=>"mA"},
     "3"=>{"raw"=>620, "voltage"=>0.4996336996336996, "converted_value"=>249.81684981684978, "converted_string"=>"  5V Current 249.8 mA", "units"=>"mA"},
     "4"=>{"raw"=>334, "voltage"=>0.26915750915750913, "converted_value"=>269.15750915750914, "converted_string"=>"3.3V Current 269.2 mA", "units"=>"mA"},
     "5"=>{"raw"=>4024, "voltage"=>3.2427838827838826, "converted_value"=>4024, "converted_string"=>"Slow ADC 5", "units"=>"ch"},
     "6"=>{"raw"=>4021, "voltage"=>3.2403663003663, "converted_value"=>4021, "converted_string"=>"Slow ADC 6", "units"=>"ch"},
     "7"=>{"raw"=>4021, "voltage"=>3.2403663003663, "converted_value"=>4021, "converted_string"=>"Slow ADC 7", "units"=>"ch"}},
   "bme280"=>
    {"temperature"=>{"value"=>27.07, "units"=>"degC"}, "pressure"=>{"value"=>1013.03, "units"=>"mb"}, "humidity"=>{"value"=>42.56, "units"=>"%"}},
   "slide_switch"=>"off",
   "boot_count"=>5}, 
 "subsystem"=>"hk"}
[2] pry(main)> 
```