### PR TITLE
PR: growth_daq supports a new trigger mode (4)

### DIFF
--- a/daq/src/GROWTH_FY2015_ADC.hh
+++ b/daq/src/GROWTH_FY2015_ADC.hh
@@ -876,7 +876,7 @@ public:
 	std::string DetectorID;
 	size_t PreTriggerSamples = 4;
 	size_t PostTriggerSamples = 1000;
-	std::vector<TriggerMode> TriggerMode { TriggerMode::StartThreshold_NSamples_CloseThreshold,
+	std::vector<enum TriggerMode> TriggerModes { TriggerMode::StartThreshold_NSamples_CloseThreshold,
 			TriggerMode::StartThreshold_NSamples_CloseThreshold, TriggerMode::StartThreshold_NSamples_CloseThreshold,
 			TriggerMode::StartThreshold_NSamples_CloseThreshold };
 	size_t SamplesInEventPacket = 1000;
@@ -945,9 +945,9 @@ public:
 		this->PostTriggerSamples = yaml_root["PostTriggerSamples"].as<size_t>();
 		{
 			// Convert integer-type trigger mode to TriggerMode enum type
-			const std::vector<size_t> triggerModeInt = yaml_root["TriggerMode"].as<std::vector<size_t>>();
+			const std::vector<size_t> triggerModeInt = yaml_root["TriggerModes"].as<std::vector<size_t>>();
 			for (size_t i = 0; i < triggerModeInt.size(); i++) {
-				this->TriggerMode[i] = static_cast<enum TriggerMode>(triggerModeInt.at(i));
+				this->TriggerModes[i] = static_cast<enum TriggerMode>(triggerModeInt.at(i));
 			}
 		}
 		this->SamplesInEventPacket = yaml_root["SamplesInEventPacket"].as<size_t>();
@@ -966,9 +966,9 @@ public:
 		cout << "PreTriggerSamples                 : " << this->PreTriggerSamples << endl;
 		cout << "PostTriggerSamples                : " << this->PostTriggerSamples << endl;
 		{
-			cout << "TriggerMode                       : [";
+			cout << "TriggerModes                      : [";
 			std::vector<size_t> triggerModeInt { };
-			for (const auto mode : this->TriggerMode) {
+			for (const auto mode : this->TriggerModes) {
 				triggerModeInt.push_back(static_cast<size_t>(mode));
 			}
 			cout << CxxUtilities::String::join(triggerModeInt, ", ") << "]" << endl;
@@ -996,7 +996,7 @@ public:
 				this->setDepthOfDelay(ch, PreTriggerSamples);
 
 				//trigger mode
-				const auto triggerMode = this->TriggerMode.at(ch);
+				const auto triggerMode = this->TriggerModes.at(ch);
 				this->setTriggerMode(ch, triggerMode);
 
 				//threshold

--- a/daq/src/GROWTH_FY2015_ADC.hh
+++ b/daq/src/GROWTH_FY2015_ADC.hh
@@ -233,14 +233,10 @@ public:
 				nReceivedEvents_latch = parent->nReceivedEvents;
 				delta = nReceivedEvents_latch - nReceivedEvents_previous;
 				nReceivedEvents_previous = nReceivedEvents_latch;
-				cout << "GROWTH_FY2015_ADC received " << dec
-						<< parent->nReceivedEvents << " events (delta=" << dec
+				cout << "GROWTH_FY2015_ADC received " << dec << parent->nReceivedEvents << " events (delta=" << dec
 						<< delta << ")." << endl;
-				cout
-						<< "GROWTH_FY2015_ADC_Type::EventDecoder available Event instances = "
-						<< dec
-						<< this->eventDecoder->getNAllocatedEventInstances()
-						<< endl;
+				cout << "GROWTH_FY2015_ADC_Type::EventDecoder available Event instances = " << dec
+						<< this->eventDecoder->getNAllocatedEventInstances() << endl;
 			}
 		}
 	};
@@ -291,8 +287,7 @@ public:
 		adcRMAPTargetNode->setTargetLogicalAddress(0xFE);
 		adcRMAPTargetNode->setInitiatorLogicalAddress(0xFE);
 
-		this->rmapHandler = new RMAPHandlerUART(deviceName,
-				{ adcRMAPTargetNode });
+		this->rmapHandler = new RMAPHandlerUART(deviceName, { adcRMAPTargetNode });
 		bool connected = this->rmapHandler->connectoToSpaceWireToGigabitEther();
 		if (!connected) {
 			cerr << "SpaceWire interface could not be opened." << endl;
@@ -302,21 +297,17 @@ public:
 		}
 
 		//
-		rmapIniaitorForGPSRegisterAccess = new RMAPInitiator(
-				this->rmapHandler->getRMAPEngine());
+		rmapIniaitorForGPSRegisterAccess = new RMAPInitiator(this->rmapHandler->getRMAPEngine());
 
 		//create an instance of ChannelManager
-		this->channelManager = new ChannelManager(rmapHandler,
-				adcRMAPTargetNode);
+		this->channelManager = new ChannelManager(rmapHandler, adcRMAPTargetNode);
 
 		//create an instance of ConsumerManager
-		this->consumerManager = new ConsumerManagerEventFIFO(rmapHandler,
-				adcRMAPTargetNode);
+		this->consumerManager = new ConsumerManagerEventFIFO(rmapHandler, adcRMAPTargetNode);
 
 		//create instances of ADCChannelRegister
 		for (size_t i = 0; i < SpaceFibreADC::NumberOfChannels; i++) {
-			this->channelModules[i] = new ChannelModule(rmapHandler,
-					adcRMAPTargetNode, i);
+			this->channelModules[i] = new ChannelModule(rmapHandler, adcRMAPTargetNode, i);
 		}
 
 		//event decoder
@@ -333,9 +324,7 @@ public:
 public:
 	~GROWTH_FY2015_ADC() {
 		using namespace std;
-		cout
-				<< "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deconstructing GROWTH_FY2015_ADC instance."
-				<< endl;
+		cout << "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deconstructing GROWTH_FY2015_ADC instance." << endl;
 		/*
 		 cout << "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Stopping dump thread." << endl;
 		 if (this->dumpThread != NULL && this->dumpThread->isInRunMethod()) {
@@ -343,15 +332,11 @@ public:
 		 delete this->dumpThread;
 		 }*/
 
-		cout
-				<< "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deleting RMAP Handler."
-				<< endl;
+		cout << "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deleting RMAP Handler." << endl;
 		delete rmapIniaitorForGPSRegisterAccess;
 		delete rmapHandler;
 
-		cout
-				<< "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deleting internal modules."
-				<< endl;
+		cout << "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deleting internal modules." << endl;
 		delete this->channelManager;
 		delete this->consumerManager;
 		for (size_t i = 0; i < SpaceFibreADC::NumberOfChannels; i++) {
@@ -359,9 +344,7 @@ public:
 		}
 		delete eventDecoder;
 
-		cout
-				<< "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deleting GPS Data FIFO read buffer."
-				<< endl;
+		cout << "GROWTH_FY2015_ADC::~GROWTH_FY2015_ADC(): Deleting GPS Data FIFO read buffer." << endl;
 		if (gpsDataFIFOReadBuffer != NULL) {
 			delete gpsDataFIFOReadBuffer;
 		}
@@ -379,8 +362,7 @@ public:
 	/** Returns FPGA Type as string.
 	 */
 	uint32_t getFPGAType() {
-		uint32_t fpgaType = this->rmapHandler->read32BitRegister(
-				adcRMAPTargetNode, AddressOfFPGATypeRegister_L);
+		uint32_t fpgaType = this->rmapHandler->read32BitRegister(adcRMAPTargetNode, AddressOfFPGATypeRegister_L);
 		return fpgaType;
 	}
 
@@ -389,8 +371,7 @@ public:
 	 */
 	uint32_t getFPGAVersion() {
 		using namespace std;
-		uint32_t fpgaVersion = this->rmapHandler->read32BitRegister(
-				adcRMAPTargetNode, AddressOfFPGAVersionRegister_L);
+		uint32_t fpgaVersion = this->rmapHandler->read32BitRegister(adcRMAPTargetNode, AddressOfFPGAVersionRegister_L);
 		return fpgaVersion;
 	}
 
@@ -399,8 +380,7 @@ public:
 	 */
 	std::string getGPSRegister() {
 		using namespace std;
-		this->rmapHandler->read(adcRMAPTargetNode, AddressOfGPSTimeRegister,
-				LengthOfGPSTimeRegister, gpsTimeRegister);
+		this->rmapHandler->read(adcRMAPTargetNode, AddressOfGPSTimeRegister, LengthOfGPSTimeRegister, gpsTimeRegister);
 		std::stringstream ss;
 		for (size_t i = 0; i < LengthOfGPSTimeRegister; i++) {
 			ss << gpsTimeRegister[i];
@@ -410,8 +390,7 @@ public:
 
 public:
 	uint8_t* getGPSRegisterUInt8() {
-		this->rmapHandler->read(adcRMAPTargetNode, AddressOfGPSTimeRegister,
-				LengthOfGPSTimeRegister, gpsTimeRegister);
+		this->rmapHandler->read(adcRMAPTargetNode, AddressOfGPSTimeRegister, LengthOfGPSTimeRegister, gpsTimeRegister);
 		gpsTimeRegister[LengthOfGPSTimeRegister] = 0x00;
 		return gpsTimeRegister;
 	}
@@ -422,8 +401,7 @@ public:
 	 */
 	void clearGPSDataFIFO() {
 		uint8_t dummy[2];
-		this->rmapHandler->read(adcRMAPTargetNode,
-				AddressOfGPSDataFIFOResetRegister, 2, dummy);
+		this->rmapHandler->read(adcRMAPTargetNode, AddressOfGPSDataFIFOResetRegister, 2, dummy);
 	}
 
 public:
@@ -437,11 +415,9 @@ public:
 		if (gpsDataFIFOReadBuffer == NULL) {
 			gpsDataFIFOReadBuffer = new uint8_t[GPSDataFIFODepthInBytes];
 		}
-		this->rmapHandler->read(adcRMAPTargetNode,
-				AddressOfGPSDataFIFOResetRegister, GPSDataFIFODepthInBytes,
+		this->rmapHandler->read(adcRMAPTargetNode, AddressOfGPSDataFIFOResetRegister, GPSDataFIFODepthInBytes,
 				gpsDataFIFOReadBuffer);
-		memcpy(&(gpsDataFIFOData[0]), gpsDataFIFOReadBuffer,
-				GPSDataFIFODepthInBytes);
+		memcpy(&(gpsDataFIFOData[0]), gpsDataFIFOReadBuffer, GPSDataFIFODepthInBytes);
 		return gpsDataFIFOData;
 	}
 
@@ -453,8 +429,7 @@ public:
 	ChannelModule* getChannelRegister(int chNumber) {
 		using namespace std;
 		if (Debug::adcbox()) {
-			cout << "GROWTH_FY2015_ADC::getChannelRegister(" << chNumber << ")"
-					<< endl;
+			cout << "GROWTH_FY2015_ADC::getChannelRegister(" << chNumber << ")" << endl;
 		}
 		return channelModules[chNumber];
 	}
@@ -589,14 +564,12 @@ public:
 	 * @param chNumber channel number
 	 * @param triggerMode trigger mode (see TriggerMode)
 	 */
-	void setTriggerMode(size_t chNumber, TriggerMode triggerMode)
-			throw (SpaceFibreADCException) {
+	void setTriggerMode(size_t chNumber, TriggerMode triggerMode) throw (SpaceFibreADCException) {
 		if (chNumber < SpaceFibreADC::NumberOfChannels) {
 			channelModules[chNumber]->setTriggerMode(triggerMode);
 		} else {
 			using namespace std;
-			cerr << "Error in setTriggerMode(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in setTriggerMode(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -636,14 +609,12 @@ public:
 	/** Sets Leading Trigger Threshold.
 	 * @param threshold an adc value for leading trigger threshold
 	 */
-	void setStartingThreshold(size_t chNumber, uint32_t threshold)
-			throw (SpaceFibreADCException) {
+	void setStartingThreshold(size_t chNumber, uint32_t threshold) throw (SpaceFibreADCException) {
 		if (chNumber < SpaceFibreADC::NumberOfChannels) {
 			channelModules[chNumber]->setStartingThreshold(threshold);
 		} else {
 			using namespace std;
-			cerr << "Error in setStartingThreshold(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in setStartingThreshold(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -652,14 +623,12 @@ public:
 	/** Sets Trailing Trigger Threshold.
 	 * @param threshold an adc value for trailing trigger threshold
 	 */
-	void setClosingThreshold(size_t chNumber, uint32_t threshold)
-			throw (SpaceFibreADCException) {
+	void setClosingThreshold(size_t chNumber, uint32_t threshold) throw (SpaceFibreADCException) {
 		if (chNumber < SpaceFibreADC::NumberOfChannels) {
 			channelModules[chNumber]->setClosingThreshold(threshold);
 		} else {
 			using namespace std;
-			cerr << "Error in setClosingThreshold(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in setClosingThreshold(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -668,14 +637,12 @@ public:
 	/** Sets TriggerBusMask which is used in TriggerMode==TriggerBus.
 	 * @param enabledChannels array of enabled trigger bus channels.
 	 */
-	void setTriggerBusMask(size_t chNumber, std::vector<size_t> enabledChannels)
-			throw (SpaceFibreADCException) {
+	void setTriggerBusMask(size_t chNumber, std::vector<size_t> enabledChannels) throw (SpaceFibreADCException) {
 		if (chNumber < SpaceFibreADC::NumberOfChannels) {
 			channelModules[chNumber]->setTriggerBusMask(enabledChannels);
 		} else {
 			using namespace std;
-			cerr << "Error in setTriggerBusMask(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in setTriggerBusMask(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -686,14 +653,12 @@ public:
 	 * before of the trigger timing.
 	 * @param depthOfDelay number of samples retarded
 	 */
-	void setDepthOfDelay(size_t chNumber, uint32_t depthOfDelay)
-			throw (SpaceFibreADCException) {
+	void setDepthOfDelay(size_t chNumber, uint32_t depthOfDelay) throw (SpaceFibreADCException) {
 		if (chNumber < SpaceFibreADC::NumberOfChannels) {
 			channelModules[chNumber]->setDepthOfDelay(depthOfDelay);
 		} else {
 			using namespace std;
-			cerr << "Error in setDepthOfDelay(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in setDepthOfDelay(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -707,8 +672,7 @@ public:
 			return channelModules[chNumber]->getLivetime();
 		} else {
 			using namespace std;
-			cerr << "Error in getLivetime(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in getLivetime(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -722,8 +686,7 @@ public:
 			return channelModules[chNumber]->getCurrentADCValue();
 		} else {
 			using namespace std;
-			cerr << "Error in getCurrentADCValue(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in getCurrentADCValue(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -736,8 +699,7 @@ public:
 			channelModules[chNumber]->turnADCPower(true);
 		} else {
 			using namespace std;
-			cerr << "Error in turnOnADCPower(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in turnOnADCPower(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -750,8 +712,7 @@ public:
 			channelModules[chNumber]->turnADCPower(false);
 		} else {
 			using namespace std;
-			cerr << "Error in turnOffADCPower(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in turnOffADCPower(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -814,8 +775,7 @@ public:
 			channelModules[chNumber]->sendCPUTrigger();
 		} else {
 			using namespace std;
-			cerr << "Error in sendCPUTrigger(): invalid channel number "
-					<< chNumber << endl;
+			cerr << "Error in sendCPUTrigger(): invalid channel number " << chNumber << endl;
 			throw SpaceFibreADCException::InvalidChannelNumber;
 		}
 	}
@@ -826,8 +786,7 @@ public:
 	 */
 	void sendCPUTrigger() {
 		using namespace std;
-		for (size_t chNumber = 0; chNumber < SpaceFibreADC::NumberOfChannels;
-				chNumber++) {
+		for (size_t chNumber = 0; chNumber < SpaceFibreADC::NumberOfChannels; chNumber++) {
 			if (this->ChannelEnable[chNumber] == true) { //if enabled
 				cout << "CPU Trigger to Channel " << chNumber << endl;
 				channelModules[chNumber]->sendCPUTrigger();
@@ -898,8 +857,7 @@ public:
 			//livetime
 			hkData.livetime[i] = channelModules[i]->getLivetime();
 			//acquisition status
-			hkData.acquisitionStarted[i] =
-					channelManager->isAcquisitionCompleted(i);
+			hkData.acquisitionStarted[i] = channelManager->isAcquisitionCompleted(i);
 		}
 
 		return hkData;
@@ -918,10 +876,8 @@ public:
 	std::string DetectorID;
 	size_t PreTriggerSamples = 4;
 	size_t PostTriggerSamples = 1000;
-	std::vector<TriggerMode> TriggerMode {
-			TriggerMode::StartThreshold_NSamples_CloseThreshold,
-			TriggerMode::StartThreshold_NSamples_CloseThreshold,
-			TriggerMode::StartThreshold_NSamples_CloseThreshold,
+	std::vector<TriggerMode> TriggerMode { TriggerMode::StartThreshold_NSamples_CloseThreshold,
+			TriggerMode::StartThreshold_NSamples_CloseThreshold, TriggerMode::StartThreshold_NSamples_CloseThreshold,
 			TriggerMode::StartThreshold_NSamples_CloseThreshold };
 	size_t SamplesInEventPacket = 1000;
 	size_t DownSamplingFactorForSavedWaveform = 1;
@@ -931,8 +887,7 @@ public:
 
 public:
 	size_t getNSamplesInEventListFile() {
-		return (this->SamplesInEventPacket)
-				/ this->DownSamplingFactorForSavedWaveform;
+		return (this->SamplesInEventPacket) / this->DownSamplingFactorForSavedWaveform;
 	}
 
 public:
@@ -967,18 +922,16 @@ public:
 	void loadConfigurationFile(std::string inputFileName) {
 		using namespace std;
 		YAML::Node yaml_root = YAML::LoadFile(inputFileName);
-		std::vector<std::string> mustExistKeywords = { "DetectorID",
-				"PreTriggerSamples", "PostTriggerSamples",
-				"SamplesInEventPacket", "DownSamplingFactorForSavedWaveform",
-				"ChannelEnable", "TriggerThresholds", "TriggerCloseThresholds" };
+		std::vector<std::string> mustExistKeywords = { "DetectorID", "PreTriggerSamples", "PostTriggerSamples",
+				"SamplesInEventPacket", "DownSamplingFactorForSavedWaveform", "ChannelEnable", "TriggerThresholds",
+				"TriggerCloseThresholds" };
 
 		//---------------------------------------------
 		//check keyword existence
 		//---------------------------------------------
 		for (auto keyword : mustExistKeywords) {
 			if (!yaml_root[keyword].IsDefined()) {
-				cerr << "Error: " << keyword
-						<< " is not defined in the configuration file." << endl;
+				cerr << "Error: " << keyword << " is not defined in the configuration file." << endl;
 				dumpMustExistKeywords();
 				exit(-1);
 			}
@@ -997,16 +950,11 @@ public:
 				this->TriggerMode[i] = static_cast<enum TriggerMode>(triggerModeInt.at(i));
 			}
 		}
-		this->SamplesInEventPacket =
-				yaml_root["SamplesInEventPacket"].as<size_t>();
-		this->DownSamplingFactorForSavedWaveform =
-				yaml_root["DownSamplingFactorForSavedWaveform"].as<size_t>();
-		this->ChannelEnable =
-				yaml_root["ChannelEnable"].as<std::vector<bool>>();
-		this->TriggerThresholds = yaml_root["TriggerThresholds"].as<
-				std::vector<uint16_t>>();
-		this->TriggerCloseThresholds = yaml_root["TriggerCloseThresholds"].as<
-				std::vector<uint16_t>>();
+		this->SamplesInEventPacket = yaml_root["SamplesInEventPacket"].as<size_t>();
+		this->DownSamplingFactorForSavedWaveform = yaml_root["DownSamplingFactorForSavedWaveform"].as<size_t>();
+		this->ChannelEnable = yaml_root["ChannelEnable"].as<std::vector<bool>>();
+		this->TriggerThresholds = yaml_root["TriggerThresholds"].as<std::vector<uint16_t>>();
+		this->TriggerCloseThresholds = yaml_root["TriggerCloseThresholds"].as<std::vector<uint16_t>>();
 
 		//---------------------------------------------
 		//dump setting
@@ -1014,34 +962,25 @@ public:
 		cout << "#---------------------------------------------" << endl;
 		cout << "# Configuration" << endl;
 		cout << "#---------------------------------------------" << endl;
-		cout << "DetectorID                        : " << this->DetectorID
-				<< endl;
-		cout << "PreTriggerSamples                 : "
-				<< this->PreTriggerSamples << endl;
-		cout << "PostTriggerSamples                : "
-				<< this->PostTriggerSamples << endl;
+		cout << "DetectorID                        : " << this->DetectorID << endl;
+		cout << "PreTriggerSamples                 : " << this->PreTriggerSamples << endl;
+		cout << "PostTriggerSamples                : " << this->PostTriggerSamples << endl;
 		{
 			cout << "TriggerMode                       : [";
 			std::vector<size_t> triggerModeInt { };
 			for (const auto mode : this->TriggerMode) {
 				triggerModeInt.push_back(static_cast<size_t>(mode));
 			}
-			cout << CxxUtilities::String::join(triggerModeInt, ", ") << "]"
-					<< endl;
+			cout << CxxUtilities::String::join(triggerModeInt, ", ") << "]" << endl;
 		}
-		cout << "SamplesInEventPacket              : "
-				<< this->SamplesInEventPacket << endl;
-		cout << "DownSamplingFactorForSavedWaveform: "
-				<< this->DownSamplingFactorForSavedWaveform << endl;
-		cout << "ChannelEnable                     : ["
-				<< CxxUtilities::String::join(this->ChannelEnable, ", ") << "]"
+		cout << "SamplesInEventPacket              : " << this->SamplesInEventPacket << endl;
+		cout << "DownSamplingFactorForSavedWaveform: " << this->DownSamplingFactorForSavedWaveform << endl;
+		cout << "ChannelEnable                     : [" << CxxUtilities::String::join(this->ChannelEnable, ", ") << "]"
 				<< endl;
-		cout << "TriggerThresholds                 : ["
-				<< CxxUtilities::String::join(this->TriggerThresholds, ", ")
+		cout << "TriggerThresholds                 : [" << CxxUtilities::String::join(this->TriggerThresholds, ", ")
 				<< "]" << endl;
 		cout << "TriggerCloseThresholds            : ["
-				<< CxxUtilities::String::join(this->TriggerCloseThresholds,
-						", ") << "]" << endl;
+				<< CxxUtilities::String::join(this->TriggerCloseThresholds, ", ") << "]" << endl;
 		cout << endl;
 
 		cout << "//---------------------------------------------" << endl;
@@ -1065,8 +1004,7 @@ public:
 				this->setClosingThreshold(ch, TriggerCloseThresholds[ch]);
 
 				//adc clock 50MHz
-				this->setAdcClock(
-						SpaceFibreADC::ADCClockFrequency::ADCClock50MHz);
+				this->setAdcClock(SpaceFibreADC::ADCClockFrequency::ADCClock50MHz);
 
 				//turn on ADC
 				this->turnOnADCPower(ch);

--- a/daq/src/GROWTH_FY2015_ADCModules/ChannelManager.hh
+++ b/daq/src/GROWTH_FY2015_ADCModules/ChannelManager.hh
@@ -8,8 +8,8 @@
 #ifndef CHANNELMANAGER_HH_
 #define CHANNELMANAGER_HH_
 
-#include "SpaceWireRMAPLibrary/Boards/SpaceFibreADCBoardModules/RMAPHandler.hh"
-#include "SpaceWireRMAPLibrary/Boards/SpaceFibreADCBoardModules/Types.hh"
+#include "GROWTH_FY2015_ADCModules/RMAPHandler.hh"
+#include "GROWTH_FY2015_ADCModules/Types.hh"
 
 /** A class which represents ChannelManager module on VHDL logic.
  * This module controls start/stop, preset mode, livetime, and

--- a/daq/src/GROWTH_FY2015_ADCModules/ChannelModule.hh
+++ b/daq/src/GROWTH_FY2015_ADCModules/ChannelModule.hh
@@ -33,6 +33,9 @@ public:
 	uint32_t AddressOf_DigitalFilterTrigger_ThresholdDeltaRegister;
 	uint32_t AddressOf_DigitalFilterTrigger_WidthRegister;
 	uint32_t AddressOf_DigitalFilterTrigger_HitPattern_FilterCoefficientSelectorRegister;
+	uint32_t AddressOf_Status1Register;
+	uint32_t AddressOf_TriggerCountRegisterL;
+	uint32_t AddressOf_TriggerCountRegisterH;
 
 private:
 	RMAPHandler* rmapHandler;
@@ -59,23 +62,27 @@ public:
 		AddressOf_LivetimeRegisterH = BA + 0x0010;
 		AddressOf_CurrentAdcDataRegister = BA + 0x0012;
 		AddressOf_CPUTriggerRegister = BA + 0x0014;
-		AddressOf_DigitalFilterTrigger_ThresholdDeltaRegister = BA + 0x0018;
-		AddressOf_DigitalFilterTrigger_WidthRegister = BA + 0x001a;
-		AddressOf_DigitalFilterTrigger_HitPattern_FilterCoefficientSelectorRegister = BA + 0x0020;
+		AddressOf_TriggerCountRegisterL = BA + 0x0016;
+		AddressOf_TriggerCountRegisterH = BA + 0x0018;
+		/*
+		 AddressOf_DigitalFilterTrigger_ThresholdDeltaRegister = BA + 0x0018;
+		 AddressOf_DigitalFilterTrigger_WidthRegister = BA + 0x001a;
+		 AddressOf_DigitalFilterTrigger_HitPattern_FilterCoefficientSelectorRegister = BA + 0x0020;
+		 */
 		AddressOf_TriggerBusMaskRegister = BA + 0x0024;
+		AddressOf_Status1Register = BA + 0x0030;
+		AddressOf_TriggerCountRegisterL = AddressOf_TriggerCountRegisterH;
+
 	}
 
 public:
 	void setRegister(uint32_t address, uint16_t data) {
-		std::vector<uint8_t> writeData = { static_cast<uint8_t>(data / 0x100), static_cast<uint8_t>(data % 0x100) };
-		rmapHandler->write(adcRMAPTargetNode, address, &writeData[0], writeData.size());
+		rmapHandler->setRegister(address, data);
 	}
 
 public:
 	uint16_t getRegister(uint32_t address) {
-		std::vector<uint8_t> readData(2);
-		rmapHandler->read(adcRMAPTargetNode, address, 2, &readData[0]);
-		return (uint16_t) (readData[0] * 0x100 + readData[1]);
+		return rmapHandler->getRegister(address);
 	}
 
 public:
@@ -89,7 +96,7 @@ public:
 	 * Trigger Bus (AND) = TriggerBusSelectedAND<br>
 	 * @param triggerMode trigger mode number
 	 */
-	void setTriggerMode(SpaceFibreADC::TriggerMode triggerMode) {
+	void setTriggerMode(GROWTH_FY2015_ADC_Type::TriggerMode triggerMode) {
 		uint16_t triggerModeInteger = static_cast<uint16_t>(triggerMode);
 		using namespace std;
 		if (Debug::channelmodule()) {
@@ -100,6 +107,22 @@ public:
 			uint16_t triggerModeRead = this->getRegister(AddressOf_TriggerModeRegister);
 			cout << "done(" << hex << setw(4) << triggerModeRead << dec << ")" << endl;
 		}
+	}
+
+public:
+	/** Returns trigger mode.
+	 * See setTrigger() for returned values.
+	 */
+	int getTriggerMode() {
+		using namespace std;
+		if (Debug::channelmodule()) {
+			cout << "channelmodule(" << chNumber << ") getting TriggerMode...";
+		}
+		uint16_t triggerModeInteger = this->getRegister(AddressOf_TriggerModeRegister);
+		if (Debug::channelmodule()) {
+			cout << "done(" << hex << setw(4) << triggerModeInteger << dec << ")" << endl;
+		}
+		return triggerModeInteger;
 	}
 
 public:
@@ -251,6 +274,54 @@ public:
 			cout << hex << setw(4) << setfill('0') << adcvalue << dec << endl;
 		}
 		return adcvalue;
+	}
+
+public:
+	/** Reads Status Register. Result will be returned as string.
+	 * @return stringified status
+	 */
+	std::string getStatus() {
+		using namespace std;
+		uint16_t statusRegister = rmapHandler->getRegister(AddressOf_Status1Register);
+		std::stringstream ss;
+		/*
+		 Status1Register <= (                             --
+		 -- Trigger/Veto status
+		 0      => Veto_internal,                       --1
+		 1      => InternalModule2ChModule.TriggerOut,  --2
+		 2      => '0',                                 --4
+		 3      => ChMgr2ChModule.Veto,                 --8
+		 4      => TriggerModuleVeto,                   --1
+		 5      => AdcPowerDownModeRegister(0),         --2
+		 6      => '1',                                 --4
+		 7      => '1',                                 --8
+		 -- EventBuffer status
+		 8      => BufferNoGood,                        --1
+		 9      => NoRoomForMoreEvent,                  --2
+		 10     => hasEvent,                            --4
+		 others => '1'
+		 );
+		 */
+		ss << "Veto_internal : " << ((statusRegister & 0x0001) >> 0) << endl;
+		ss << "TriggerOut    : " << ((statusRegister & 0x0002) >> 1) << endl;
+		ss << "ChMgr Veto    : " << ((statusRegister & 0x0008) >> 3) << endl;
+		ss << "TrgModuleVeto : " << ((statusRegister & 0x0010) >> 4) << endl;
+		ss << "ADCPowerDown  : " << ((statusRegister & 0x0020) >> 5) << endl;
+		ss << "BufferNoGood  : " << ((statusRegister & 0x0100) >> 8) << endl;
+		ss << "NoRoomForEvt  : " << ((statusRegister & 0x0200) >> 9) << endl;
+		ss << "hasEvent      : " << ((statusRegister & 0x0400) >> 10) << endl;
+
+		return ss.str();
+	}
+
+public:
+	/** Reads TriggerCountRegister.
+	 * @return trigger count
+	 */
+	size_t getTriggerCount() {
+		size_t low = rmapHandler->getRegister(AddressOf_TriggerCountRegisterL);
+		size_t high = rmapHandler->getRegister(AddressOf_TriggerCountRegisterH);
+		return (high << 16) + low;
 	}
 };
 

--- a/daq/src/GROWTH_FY2015_ADCModules/Types.hh
+++ b/daq/src/GROWTH_FY2015_ADCModules/Types.hh
@@ -8,7 +8,7 @@
 #ifndef GROWTH_FY2015_ADC_TYPES_HH_
 #define GROWTH_FY2015_ADC_TYPES_HH_
 
-#include "SpaceWireRMAPLibrary/Boards/SpaceFibreADCBoardModules/Constants.hh"
+#include "GROWTH_FY2015_ADCModules/Constants.hh"
 
 namespace GROWTH_FY2015_ADC_Type {
 enum class TriggerMode
@@ -16,6 +16,7 @@ enum class TriggerMode
 		StartThreshold_NSamples_AutoClose = 1, //
 	CommonGateIn = 2, //
 	StartThreshold_NSamples_CloseThreshold = 3, //
+	DeltaAboveDelayedADC_NumberOfSamples = 4, //
 	CPUTrigger = 5, //
 	TriggerBusSelectedOR = 8, //
 	TriggerBusSelectedAND = 9


### PR DESCRIPTION
- Confirmed to work with the new FPGA image #20.
- See the above test result for histogram and waveform taken with the new "Baseline + Delta" trigger mode (`TriggerMode=4`).
- In `TriggerMode=4`, `TriggerCloseThresholds` is not actually used (as set to `0` in the following configuration file).

YAML configuration file used in the test:
```
DetectorID: growth-fy2017z
PreTriggerSamples: 20
PostTriggerSamples: 500
SamplesInEventPacket: 1
DownSamplingFactorForSavedWaveform: 1
ChannelEnable: [yes,no,no,no]
TriggerModes: [4, 4, 4, 4]
TriggerThresholds: [20, 20, 20, 20]
TriggerCloseThresholds: [0, 0, 0, 0]
```