### PR TITLE
PR: FPGA MCS Version 20171104

### DIFF
--- a/fpga/mcs/README.md
+++ b/fpga/mcs/README.md
@@ -39,3 +39,15 @@ E.g.
 $ growth_daq /dev/tty.usbserial--FT0K8WCSA configuration.yaml 100
 $ growth_daq /dev/ttyUSB1 configuration.yaml 100
 ```
+
+- growth_fy2016_fpga_20171104_2445_4ch_50Msps_with_triggerMode4_q128.mcs.zip
+    - All 4 channels are enabled and operated at ADC clock 50MHz.
+    - FT2232H Bank A: Pulse event measurement.
+    - FT2232H Bank B: GPS serial output (through connection from daughter card).
+    - Use Bank A (1) serial device when running `growth_daq`.
+      ```
+      $ growth_daq /dev/tty.usbserial--FT0K8WCSA configuration.yaml 100
+      or
+      $ growth_daq /dev/ttyUSB1 configuration.yaml 100
+      ```
+    

--- a/fpga/mcs/growth_fy2016_fpga_20171104_2445_4ch_50Msps_with_triggerMode4_q128.mcs.zip
+++ b/fpga/mcs/growth_fy2016_fpga_20171104_2445_4ch_50Msps_with_triggerMode4_q128.mcs.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8e1916afb5e957327c42aa36c274627fd81c01c8da46df5c914861717a62a17
+size 768919


### PR DESCRIPTION
Changes:
- Added the FPGA image `growth_fy2016_fpga_20171104_2445_4ch_50Msps_with_triggerMode4_q128.mcs` which is used in the FY2017 observation campaign.

Reviewer: @YuukiWada @MatsumotoTakahiro 