### PR TITLE
SerialPort.hh - boost compatibility

### DIFF
--- a/daq/src/SerialPort.hh
+++ b/daq/src/SerialPort.hh
@@ -242,7 +242,7 @@ private:
 public:
 	void setTimeout(double timeoutDurationInMilliSec) {
 		this->timeoutDurationInMilliSec = timeoutDurationInMilliSec;
-		timeoutDurationObject = boost::posix_time::millisec(timeoutDurationInMilliSec);
+		timeoutDurationObject = boost::posix_time::millisec(static_cast<uint32_t>(timeoutDurationInMilliSec));
 	}
 };
 


### PR DESCRIPTION
When Boost is upgraded to 1.67.00, the following incompatibility was noticed:

Before fix:
```
In file included from /Users/yuasa/git/GROWTH-DAQ/daq/src/growth_daq.cc:3:
In file included from /Users/yuasa/git/GROWTH-DAQ/daq/src/MainThread.hh:19:
In file included from /Users/yuasa/git/GROWTH-DAQ/daq/src/GROWTH_FY2015_ADC.hh:174:
In file included from /Users/yuasa/git/GROWTH-DAQ/daq/src/GROWTH_FY2015_ADCModules/RMAPHandlerUART.hh:5:
In file included from /Users/yuasa/git/GROWTH-DAQ/daq/src/SpaceWireIFOverUART.hh:42:
In file included from /Users/yuasa/git/GROWTH-DAQ/daq/src/SpaceWireSSDTPModuleUART.hh:39:
/Users/yuasa/git/GROWTH-DAQ/daq/src/SerialPort.hh:246:27: error: no matching conversion for functional-style cast from 'double' to
      'boost::posix_time::millisec' (aka 'subsecond_duration<boost::posix_time::time_duration, 1000>')
                timeoutDurationObject = boost::posix_time::millisec(timeoutDurationInMilliSec);
                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/date_time/time_duration.hpp:270:30: note: candidate constructor (the implicit copy constructor) not viable: no known
      conversion from 'double' to 'const boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000>' for 1st argument
  class BOOST_SYMBOL_VISIBLE subsecond_duration : public base_duration
                             ^
/usr/local/include/boost/date_time/time_duration.hpp:270:30: note: candidate constructor (the implicit move constructor) not viable: no known
      conversion from 'double' to 'boost::date_time::subsecond_duration<boost::posix_time::time_duration, 1000>' for 1st argument
/usr/local/include/boost/date_time/time_duration.hpp:286:59: note: candidate template ignored: disabled by 'enable_if' [with T = double]
                                typename boost::enable_if<boost::is_integral<T>, void>::type* = 0) :
```
