### PR TITLE
PR: Setup scripts updated for Raspbian/buster

### DIFF
--- a/daq/CMakeLists.txt
+++ b/daq/CMakeLists.txt
@@ -13,6 +13,8 @@ if(USE_ROOT)
     add_definitions(-DUSE_ROOT)
 endif(USE_ROOT)
 
+find_package(Boost)
+
 #=============================================
 # Initial definition of cmake variables
 #=============================================
@@ -35,6 +37,7 @@ include_directories(
   include/XMLUtilities/include
   include/CxxUtilities/includes
   ${ROOT_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 #=============================================
@@ -42,6 +45,7 @@ include_directories(
 #=============================================
 link_directories(
   ${ROOT_LIBRARY_DIR}
+  ${Boost_LIBRARIES}
 )
 
 #=============================================
@@ -63,7 +67,7 @@ target_link_libraries(growth_daq
   zmq
   xerces-c
   boost_system
-  boost_thread-mt
+  boost_thread
   ${ROOT_LIBRARIES}
 )
 if (__APPLE__)

--- a/setup/00_setup_all.sh
+++ b/setup/00_setup_all.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+set -o nounset
+set -o errexit
+
+source ./setenv.sh
+
 install -d ${git_dir}
 install -d ${log_dir}
 

--- a/setup/install_adafruit_ssd1306.sh
+++ b/setup/install_adafruit_ssd1306.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -o errexit
 source ./setenv.sh
 
 sudo apt-get install -y build-essential python-dev python-pip

--- a/setup/install_apt-get.sh
+++ b/setup/install_apt-get.sh
@@ -2,51 +2,49 @@
 
 set -o errexit
 
-apt-get install -y software-properties-common
-apt-get update
-sudo apt-get install -y automake
-apt-get install -y binutils
-apt-get install -y build-essential
-apt-get install -y chromium
-apt-get install -y cmake
-apt-get install -y curl
-apt-get install -y curl-dev
-apt-get install -y dpkg-dev
-apt-get install -y fswebcam
-apt-get install -y git
-apt-get install -y i2c-tools
-apt-get install -y imagemagick
-apt-get install -y libboost1.50-all
-apt-get install -y libbz2-dev
-apt-get install -y libcfitsio3-dev
-apt-get install -y libcurl4-openssl-dev
-apt-get install -y libexpat-dev
-apt-get install -y libjpeg8-dev
-apt-get install -y libncurses-dev
-apt-get install -y libssl-dev
-apt-get install -y libtool-bin
-apt-get install -y libx11-dev
-apt-get install -y libxerces-c-dev
-apt-get install -y libxext-dev
-apt-get install -y libxft-dev
-apt-get install -y libxpm-dev
-apt-get install -y libyaml-cpp-dev
-apt-get install -y libzmq-dev
-apt-get install -y libzmq3-dev
-apt-get install -y make
-apt-get install -y python-dev
-apt-get install -y python-imaging
-apt-get install -y python-smbus
-apt-get install -y python-zmq
-apt-get install -y rails
-apt-get install -y ruby
-apt-get install -y ruby-dev
-apt-get install -y ruby-ffi
-apt-get install -y subversion
-apt-get install -y supervisor
-apt-get install -y swig
-apt-get install -y texinfo
-apt-get install -y wget
-apt-get install -y wicd-curses
-apt-get install -y zlib1g-dev
-apt-get install -y zsh
+sudo apt-get install -y software-properties-common
+sudo apt-get update
+sudo apt-get install -y \
+  automake \
+  binutils \
+  build-essential \
+  chromium \
+  cmake \
+  curl \
+  dpkg-dev \
+  fswebcam \
+  git \
+  i2c-tools \
+  imagemagick \
+  libboost-all-dev \
+  libbz2-dev \
+  libcfitsio-dev \
+  libcurl4-openssl-dev \
+  libexpat-dev \
+  libjpeg8-dev \
+  libncurses-dev \
+  libssl-dev \
+  libtool-bin \
+  libx11-dev \
+  libxerces-c-dev \
+  libxext-dev \
+  libxft-dev \
+  libxpm-dev \
+  libyaml-cpp-dev \
+  libzmq3-dev \
+  make \
+  python-dev \
+  python-smbus \
+  python-zmq \
+  rails \
+  ruby \
+  ruby-dev \
+  ruby-ffi \
+  subversion \
+  supervisor \
+  swig \
+  texinfo \
+  wget \
+  wicd-curses \
+  zlib1g-dev \
+  zsh

--- a/setup/install_apt-get.sh
+++ b/setup/install_apt-get.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 apt-get install -y software-properties-common
 apt-get update
 sudo apt-get install -y automake

--- a/setup/install_cmake.sh
+++ b/setup/install_cmake.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 install -d $HOME/work/install/cmake
 
 pushd $HOME/work/install/cmake

--- a/setup/install_python.sh
+++ b/setup/install_python.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
-pip install numpy scipy ipython
-pip install pyzmq
+set -o errexit
+
+pip install numpy scipy ipython pyzmq

--- a/setup/install_ruby_gem.sh
+++ b/setup/install_ruby_gem.sh
@@ -2,10 +2,4 @@
 
 set -e
 
-gem install pi_piper
-gem install git
-gem install rbczmq
-gem install pry
-gem install god
-gem install serialport
-gem install m2x
+gem install pi_piper git rbczmq pry god serialport m2x

--- a/setup/install_wiringPi.sh
+++ b/setup/install_wiringPi.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-mkdir -p $HOME/work/install
-pushd $HOME/work/install
-git clone git://git.drogon.net/wiringPi
-pushd wiringPi
+set -o errexit
+
+mkdir -p "${HOME}"/work/install
+pushd "${HOME}"/work/install
+  git clone https://github.com/WiringPi/wiringpi
+pushd wiringpi
 ./build
 
 #check build

--- a/setup/setenv.sh
+++ b/setup/setenv.sh
@@ -1,3 +1,3 @@
 repo=GROWTH-DAQ
-git_dir=$HOME/git
-log_dir=$HOME/log
+git_dir="${HOME}"/git
+log_dir="${HOME}"/log


### PR DESCRIPTION
- Obsolete packages removed in the dependency install scripts.
- Added `set -o errexit` to detect unsuccessful install
- `boost_thread_mt` => `boost_thread` in `CMakefile.txt`

growth_daq compiles on Raspbery Pi:
```
pi@raspberrypi:~/git/growth-daq/daq/build $ make -j2
-- Boost version: 1.67.0
-- Configuring done
-- Generating done
-- Build files have been written to: /home/pi/git/growth-daq/daq/build
[ 50%] Linking CXX executable growth_daq
[100%] Built target growth_daq
pi@raspberrypi:~/git/growth-daq/daq/build $ uname -a
Linux raspberrypi 4.19.57-v7+ #1244 SMP Thu Jul 4 18:45:25 BST 2019 armv7l GNU/Linux
pi@raspberrypi:~/git/growth-daq/daq/build $ cat /etc/*release
PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
```