### PR TITLE
Install rbczmq on Raspberry Pi OS (Buster)

### DIFF
--- a/controller/bin/growth_display_server.py
+++ b/controller/bin/growth_display_server.py
@@ -11,9 +11,9 @@ import zmq
 import json
 import signal
 
-import Image
-import ImageDraw
-import ImageFont
+from PIL import Image
+from PIL import ImageDraw
+from PIL import ImageFont
 
 # Constants
 ip_address = "127.0.0.1"

--- a/controller/god/growth.god.conf
+++ b/controller/god/growth.god.conf
@@ -45,11 +45,12 @@ end
 FileUtils.chown_R("pi", "pi", GROWTH_DAQ_RUN_DIR)
 
 # Environmental variables
-ADDITIONAL_ENV = { 
+ADDITIONAL_ENV = {
 	"GROWTH_CONFIG_FILE" => GROWTH_CONFIG_FILE,
 	"GROWTH_KEYS_FILE" => "#{GIT_DIR}/GROWTH-Keys/growth-keys.json",
 	"GROWTH_REPOSITORY" => GROWTH_DAQ_GIT_DIR,
-	"RUBYLIB" => "#{GROWTH_CONTROLLER_LIB_DIR}:$RUBYLIB"
+	"RUBYLIB" => "#{GROWTH_CONTROLLER_LIB_DIR}:$RUBYLIB",
+  "LD_LIBRARY_PATH" => "/usr/local/lib"
 }
 
 #---------------------------------------------

--- a/setup/install_adafruit_ssd1306.sh
+++ b/setup/install_adafruit_ssd1306.sh
@@ -12,20 +12,20 @@ if [ ! -d ${git_dir}/${repo} ]; then
 fi
 
 pushd ${git_dir}/${repo}
-  if [ ! -d lib/Adafruit_Python_SSD1306 ]; then
-    git submodule init
-    git submodule update
-  fi
+#if [ ! -d lib/Adafruit_Python_SSD1306 ]; then
+git submodule init
+git submodule update
+#fi
 
-  if [ ! -d lib/Adafruit_Python_SSD1306 ]; then
+if [ ! -d lib/Adafruit_Python_SSD1306 ]; then
     echo "Error: failed to clone Adafruit_Python_SSD1306"
     exit -1
-  fi
+fi
 
-  pushd lib/Adafruit_Python_SSD1306
-    # Execute the install script
-    sudo python setup.py install
-    # Check build
-    gpio -v
-  popd
+pushd lib/Adafruit_Python_SSD1306
+# Execute the install script
+sudo python setup.py install
+# Check build
+gpio -v
+popd
 popd

--- a/setup/install_adafruit_ssd1306.sh
+++ b/setup/install_adafruit_ssd1306.sh
@@ -7,25 +7,23 @@ sudo apt-get install -y build-essential python-dev python-pip
 sudo pip install RPi.GPIO
 
 if [ ! -d ${git_dir}/${repo} ]; then
-  echo "Error: git repo does not exist (expected at ${git_dir}/${repo}). Please run 00_setup_all.sh"
-  exit -1
+  echo "Error: git repo does not exist (expected at ${git_dir}/${repo})."
+  echo "Please run 00_setup_all.sh"
+  exit 1
 fi
 
 pushd ${git_dir}/${repo}
-#if [ ! -d lib/Adafruit_Python_SSD1306 ]; then
-git submodule init
-git submodule update
-#fi
+  git submodule init
+  git submodule update
 
-if [ ! -d lib/Adafruit_Python_SSD1306 ]; then
+  if [ ! -d lib/Adafruit_Python_SSD1306 ]; then
     echo "Error: failed to clone Adafruit_Python_SSD1306"
-    exit -1
-fi
+    exit 1
+  fi
 
-pushd lib/Adafruit_Python_SSD1306
-# Execute the install script
-sudo python setup.py install
-# Check build
-gpio -v
-popd
+  pushd lib/Adafruit_Python_SSD1306
+    sudo python setup.py install
+    # Check build
+    gpio -v
+  popd
 popd

--- a/setup/install_apt-get.sh
+++ b/setup/install_apt-get.sh
@@ -31,7 +31,6 @@ sudo apt-get install -y \
   libxft-dev \
   libxpm-dev \
   libyaml-cpp-dev \
-  libzmq3-dev \
   make \
   python-dev \
   python-smbus \

--- a/setup/install_apt-get.sh
+++ b/setup/install_apt-get.sh
@@ -44,6 +44,5 @@ sudo apt-get install -y \
   swig \
   texinfo \
   wget \
-  wicd-curses \
   zlib1g-dev \
   zsh

--- a/setup/install_ruby_gem.sh
+++ b/setup/install_ruby_gem.sh
@@ -7,33 +7,38 @@ gem install pi_piper git pry god serialport m2x
 # Uninstall rbczmq if already installed.
 gem uninstall rbczmq || true
 
-apt remove -y libzmq3-dev
+# Uninstall apt-installed libzmq3-dev if already installed.
+apt remove -y libzmq3-dev || true
 
-git clone https://github.com/zeromq/zeromq4-x
-git clone https://github.com/growth-team/czmq
+pushd /tmp
 
-# Build & install zeromq
-install -d zeromq4-x/build-ubuntu
-pushd zeromq4-x/build-ubuntu
-git checkout v4.0.7
-cmake ..
-make -j8 install
+  git clone https://github.com/zeromq/zeromq4-x
+  git clone https://github.com/growth-team/czmq
+
+  # Build & install zeromq
+  install -d zeromq4-x/build-ubuntu
+  pushd zeromq4-x/build-ubuntu
+  git checkout v4.0.7
+  cmake ..
+  make -j2 install
+  popd
+
+  # Build & install czmq
+  install -d czmq/build-ubuntu
+  pushd czmq/build-ubuntu
+  git checkout raspbian-buster-support
+  cmake ..
+  make -j2 install
+  popd
+
+  # Install rbczmq
+  gem install rbczmq -- --with-system-libs
+
+  # Test "require 'rbczmq'
+  export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+  ruby -e "require 'rbczmq'"
+
 popd
-
-# Build & install czmq
-install -d czmq/build-ubuntu
-pushd czmq/build-ubuntu
-git checkout raspbian-buster-support
-cmake ..
-make -j8 install
-popd
-
-# Install rbczmq
-gem install rbczmq -- --with-system-libs
-
-# Test "require 'rbczmq'
-export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-ruby -e "require 'rbczmq'"
 
 #
 # If LD_LIBRARY_PATH is not updated, the following error occurs:

--- a/setup/install_ruby_gem.sh
+++ b/setup/install_ruby_gem.sh
@@ -40,6 +40,21 @@ pushd /tmp
 
 popd
 
+# Install libbcm2835 that supports Raspberry Pi 4
+pushd /tmp
+  rm -rf bcm2835-1.64.tar.gz bcm2835-1.64
+  wget http://www.airspayce.com/mikem/bcm2835/bcm2835-1.64.tar.gz
+  tar zxf bcm2835-1.64.tar.gz
+  cd bcm2835-1.64
+    ./configure && make
+    sudo make check
+    sudo make install
+    cd src && cc -shared bcm2835.o -o libbcm2835.so
+      sudo cp libbcm2835.so /var/lib/gems/2.5.0/gems/pi_piper-2.0.0/lib/pi_piper/
+    cd ..
+  cd ..
+popd
+
 #
 # If LD_LIBRARY_PATH is not updated, the following error occurs:
 #

--- a/setup/install_ruby_gem.sh
+++ b/setup/install_ruby_gem.sh
@@ -1,5 +1,55 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
-gem install pi_piper git rbczmq pry god serialport m2x
+gem install pi_piper git pry god serialport m2x
+
+# Uninstall rbczmq if already installed.
+gem uninstall rbczmq || true
+
+apt remove -y libzmq3-dev
+
+git clone https://github.com/zeromq/zeromq4-x
+git clone https://github.com/growth-team/czmq
+
+# Build & install zeromq
+install -d zeromq4-x/build-ubuntu
+pushd zeromq4-x/build-ubuntu
+git checkout v4.0.7
+cmake ..
+make -j8 install
+popd
+
+# Build & install czmq
+install -d czmq/build-ubuntu
+pushd czmq/build-ubuntu
+git checkout raspbian-buster-support
+cmake ..
+make -j8 install
+popd
+
+# Install rbczmq
+gem install rbczmq -- --with-system-libs
+
+# Test "require 'rbczmq'
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ruby -e "require 'rbczmq'"
+
+#
+# If LD_LIBRARY_PATH is not updated, the following error occurs:
+#
+# root@c534e1b43ce5:/data/czmq/build-ubuntu# ruby -e "require 'rbczmq'"
+# Traceback (most recent call last):
+# 	10: from -e:1:in `<main>'
+# 	 9: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:39:in `require'
+# 	 8: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
+# 	 7: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:135:in `require'
+# 	 6: from /var/lib/gems/2.5.0/gems/rbczmq-1.7.9/lib/rbczmq.rb:3:in `<top (required)>'
+# 	 5: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
+# 	 4: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
+# 	 3: from /var/lib/gems/2.5.0/gems/rbczmq-1.7.9/lib/zmq.rb:6:in `<top (required)>'
+# 	 2: from /var/lib/gems/2.5.0/gems/rbczmq-1.7.9/lib/zmq.rb:9:in `rescue in <top (required)>'
+# 	 1: from /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
+# /usr/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': libczmq.so:
+# cannot open shared object file: No such file or directory - /var/lib/gems/2.5.0/gems/rbczmq-1.7.9/lib/rbczmq_ext.so (LoadError)
+#


### PR DESCRIPTION
- Trying to make `rbczmq` compile and work on Raspberry Pi OS (Buster).
- Manually install `zeromq` and `czmq` (modified), and then install `rbczmq` via `gem install rbczmq -- --with-system-libs`

The install script will be tested on the real hardware when it becomes available.